### PR TITLE
Fix decimal separator formatting

### DIFF
--- a/make_agreem_dir_Gemini.py
+++ b/make_agreem_dir_Gemini.py
@@ -34,7 +34,7 @@ def ua_date(dt: datetime.date) -> str:
     return f"«{dd}» {UA_MONTHS_GEN[dt.month]} {dt.year} року"
 
 def with_thin_space_groups(n: Decimal) -> str:
-    return f"{n:,.2f}".replace(",", " ").replace(".", ".")
+    return f"{n:,.2f}".replace(",", " ").replace(".", ",")
 
 def find_case_num_in_crop(page) -> str | None:
     """Ищет номер дела в верхней части страницы для надежности."""


### PR DESCRIPTION
## Summary
- ensure `with_thin_space_groups` outputs numbers with spaces for thousands and comma decimal separator

## Testing
- `python -m py_compile make_agreem_dir_Gemini.py`
- `python - <<'PY'
from decimal import Decimal
from make_agreem_dir_Gemini import with_thin_space_groups
print(with_thin_space_groups(Decimal('1234567.89')))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a19f7b053c832badf120a1b9aa7faf